### PR TITLE
[update] Using the method associate in the new versions of sequelize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,10 +57,16 @@ module.exports = function importSequelizeModels(sequelizeInstance, modelsDir /* 
   if (options.associate) {
     modelsSpace.loaded.forEach(function(currentModel) {
       var schemaModels;
+      var isMigration = currentModel.options &&
+                        currentModel.options.classMethods &&
+                        typeof currentModel.options.classMethods.associate === 'function';
 
       if ('associate' in currentModel && typeof currentModel.associate === 'function') {
         schemaModels = currentModel.$schema ? modelsSpace.space[currentModel.$schema] : modelsSpace.space;
         currentModel.associate(modelsSpace.space, schemaModels);
+      } else if (isMigration) {
+        schemaModels = currentModel.$schema ? modelsSpace.space[currentModel.$schema] : modelsSpace.space;
+        currentModel.options.classMethods.associate.bind(currentModel)(modelsSpace.space, schemaModels);
       }
     });
   }


### PR DESCRIPTION
In the new versions of sequelize the method associate doen't work because this property now was migrate from `model.associate` to `model.options.classMethods.associate`. With this changes now the method associate work in the new versions of sequelize.