### PR TITLE
change sequelize.import for require

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 var path = require('path'),
     fs = require('fs'),
+    Sequelize = require('sequelize'),
     assign = require('object-assign'),
     snakeCase = require('snake-case');
 
@@ -174,7 +175,8 @@ function importModel(sequelize, _schema, SEPARATOR, pureFileName, absolutePathTo
   defineCall = require(absolutePathToFile); // eslint-disable-line global-require
 
   // call sequelize.import with a custom function to be able to pass schema's name value
-  model = sequelize.import(pathFile, function(seqInstance, Datatypes) {
+  // make it compatible for sequelize 6.3.0 since .import is deprecated
+  model = require(pathFile, function(seqInstance, Datatypes) {
     return defineCall(seqInstance, Datatypes, {
       schema: schema,
       schemaName: schema || '',
@@ -186,7 +188,7 @@ function importModel(sequelize, _schema, SEPARATOR, pureFileName, absolutePathTo
       completeTableName: completeTableName,
       separator: SEPARATOR
     });
-  });
+  })(sequelize, Sequelize);
 
   loadedModels.push(model);
 


### PR DESCRIPTION
Since sequelize.import is deprecated, require is a must for compatilibility with sequelize 6.3.0